### PR TITLE
Eliminate unnecessary paths from $LOAD_PATH

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,6 @@ begin
       :homepage      => :blackwinter,
       :dependencies  => [['narray', '>= 0.5.9']],
       :requirements  => ['GSL (http://www.gnu.org/software/gsl/)'],
-      :require_paths => %w[lib lib/gsl lib/ool ext],
 
       :extra_files => FileList['examples/**/*', 'rdoc/*'].to_a,
 


### PR DESCRIPTION
Fixed a bug that was causing "lib/gsl/gnuplot.rb" to be loaded instead of the gnuplot gem
