### PR TITLE
Fixes multiplication with floating point numbers.

### DIFF
--- a/ext/gsl/matrix_source.c
+++ b/ext/gsl/matrix_source.c
@@ -1508,7 +1508,7 @@ static VALUE FUNCTION(rb_gsl_matrix,scale)(VALUE obj, VALUE b)
   GSL_TYPE(gsl_matrix) *m = NULL, *mnew;
   Data_Get_Struct(obj, GSL_TYPE(gsl_matrix), m);
   mnew = FUNCTION(make_matrix,clone)(m);
-  FUNCTION(gsl_matrix,scale)(mnew, NUMCONV(b));
+  FUNCTION(gsl_matrix,scale)(mnew, NUMCONV2(b));
   return Data_Wrap_Struct(GSL_TYPE(cgsl_matrix), 0, FUNCTION(gsl_matrix,free), mnew);
 }
 

--- a/ext/gsl/vector_source.c
+++ b/ext/gsl/vector_source.c
@@ -1514,7 +1514,7 @@ VALUE FUNCTION(rb_gsl_vector,scale)(VALUE obj, VALUE x)
   GSL_TYPE(gsl_vector) *v, *vnew;
   Data_Get_Struct(obj, GSL_TYPE(gsl_vector), v);
   vnew = FUNCTION(make_vector,clone)(v);
-  FUNCTION(gsl_vector,scale)(vnew, NUMCONV(x));
+  FUNCTION(gsl_vector,scale)(vnew, NUMCONV2(x));
   //  return Data_Wrap_Struct(GSL_TYPE(cgsl_vector), 0, FUNCTION(gsl_vector,free), vnew);
     return Data_Wrap_Struct(VEC_ROW_COL(obj), 0, FUNCTION(gsl_vector,free), vnew);
 }


### PR DESCRIPTION
Reason for fix:
Previously the method was using `NUMCONV`, which resolved to `FIX2INT` for `GSL::Matrix::Int` or `GSL::Vector::Int`. It would use `FIX2INT` irrespective of whether the object being passed to it was a `Fixnum` or a `Float`. This, somehow caused a malfunction on my system (ruby 2.2.1 on rvm with debian 8 jessie) and the converted `INT` value would turn out to be garbage.

Converting the `NUMCONV` to `NUMCONV2` makes sure that the macro resolves to `NUM2INT` for `GSL::Matrix::Int` and `GSL::Vector::Int`. This way, it is ensured that the object, whether a `Float` or `Fixnum` is appropriately converted to an `INT` without error, since both are of type `Numeric`.

No tests break now, and I think `NUMCONV2` would be more fool-proof too.