### PR TITLE
Fix GC marking of splines

### DIFF
--- a/ext/gsl/include/rb_gsl_interp.h
+++ b/ext/gsl/include/rb_gsl_interp.h
@@ -25,6 +25,10 @@ typedef struct {
 typedef struct {
   gsl_spline *s;
   gsl_interp_accel *a;
+  VALUE rb_x;
+  VALUE rb_y;
+  gsl_vector *gsl_x;
+  gsl_vector *gsl_y;
 } rb_gsl_spline;
 
 enum {


### PR DESCRIPTION
Marking dependent Ruby objects is missing in many cases.
This commit marks vectors which store the data used by the splines:

From https://www.gnu.org/software/gsl/manual/html_node/Interpolation-Functions.html#Interpolation-Functions :
This function initializes the interpolation object interp for the data (xa,ya) where xa and ya are arrays of size size. The interpolation object (gsl_interp) does not save the data arrays xa and ya and only stores the static state computed from the data. The xa data array is always assumed to be strictly ordered, with increasing x values; the behavior for other arrangements is not defined. 