### PR TITLE
don't merge yet - reduce number of HAVE_NARRAY_H occurences

### DIFF
--- a/ext/gsl/array.c
+++ b/ext/gsl/array.c
@@ -12,9 +12,7 @@
 #include "include/rb_gsl_common.h"
 #include "include/rb_gsl_array.h"
 #include "include/rb_gsl_complex.h"
-#ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_with_narray.h"
-#endif
 
 /* global variables */
 VALUE cgsl_block, cgsl_block_int;
@@ -47,9 +45,6 @@ double* get_vector_ptr(VALUE ary, size_t *stride, size_t *n)
   gsl_vector *v = NULL;
   gsl_vector_complex *vc = NULL;
   gsl_matrix *m;
-#ifdef HAVE_NARRAY_H
-  VALUE ary2;
-#endif
   if (VECTOR_P(ary)) {
     Data_Get_Struct(ary, gsl_vector, v);
     *stride = v->stride;
@@ -67,6 +62,7 @@ double* get_vector_ptr(VALUE ary, size_t *stride, size_t *n)
     return m->data;
 #ifdef HAVE_NARRAY_H
   } else if (NA_IsNArray(ary)) {
+    VALUE ary2;
     *n = NA_TOTAL(ary);
     *stride = 1;
     ary2 = na_change_type(ary, NA_DFLOAT);

--- a/ext/gsl/block.c
+++ b/ext/gsl/block.c
@@ -18,10 +18,7 @@
 #include "include/rb_gsl_histogram.h"
 #include "include/rb_gsl_complex.h"
 #include "include/rb_gsl_poly.h"
-
-#ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_with_narray.h"
-#endif
 
 #define BASE_DOUBLE
 #include "include/templates_on.h"

--- a/ext/gsl/cheb.c
+++ b/ext/gsl/cheb.c
@@ -98,10 +98,6 @@ static VALUE rb_gsl_cheb_eval(VALUE obj, VALUE xx)
   size_t i, j, n;
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *mnew = NULL;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
   Data_Get_Struct(obj, gsl_cheb_series, p);
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch (TYPE(xx)) {
@@ -124,6 +120,8 @@ static VALUE rb_gsl_cheb_eval(VALUE obj, VALUE xx)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       GetNArray(xx, na);
       ptr1 = (double*) na->ptr;
       n = na->total;
@@ -165,10 +163,6 @@ static VALUE rb_gsl_cheb_eval_err(VALUE obj, VALUE xx)
   size_t n, i, j;
   gsl_vector *v = NULL, *vnew = NULL, *verr = NULL;
   gsl_matrix *m = NULL, *mnew = NULL, *merr = NULL;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2, *ptr3;
-#endif
   Data_Get_Struct(obj, gsl_cheb_series, p);
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch (TYPE(xx)) {
@@ -195,6 +189,8 @@ static VALUE rb_gsl_cheb_eval_err(VALUE obj, VALUE xx)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2, *ptr3;
       GetNArray(xx, na);
       ptr1 = (double*) na->ptr;
       n = na->total;
@@ -251,10 +247,6 @@ static VALUE rb_gsl_cheb_eval_n(VALUE obj, VALUE nn, VALUE xx)
   size_t n, order, i, j;
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *mnew = NULL;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
   CHECK_FIXNUM(nn);
   order = FIX2INT(nn);
   Data_Get_Struct(obj, gsl_cheb_series, p);
@@ -279,6 +271,8 @@ static VALUE rb_gsl_cheb_eval_n(VALUE obj, VALUE nn, VALUE xx)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       GetNArray(xx, na);
       ptr1 = (double*) na->ptr;
       n = na->total;
@@ -321,10 +315,6 @@ static VALUE rb_gsl_cheb_eval_n_err(VALUE obj, VALUE nn, VALUE xx)
   size_t n, order, i, j;
   gsl_vector *v, *vnew, *verr;
   gsl_matrix *m, *mnew, *merr;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2, *ptr3;
-#endif
   CHECK_FIXNUM(nn);
   order = FIX2INT(nn);
   Data_Get_Struct(obj, gsl_cheb_series, p);
@@ -353,6 +343,8 @@ static VALUE rb_gsl_cheb_eval_n_err(VALUE obj, VALUE nn, VALUE xx)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2, *ptr3;
       GetNArray(xx, na);
       ptr1 = (double*) na->ptr;
       n = na->total;

--- a/ext/gsl/cheb.c
+++ b/ext/gsl/cheb.c
@@ -15,9 +15,6 @@
 #include "include/rb_gsl_function.h"
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_chebyshev.h>
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
 
 static VALUE cgsl_cheb;
 

--- a/ext/gsl/deriv.c
+++ b/ext/gsl/deriv.c
@@ -15,9 +15,6 @@
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_deriv.h>
 #define RB_GSL_DERIV_H_DEFAULT (1e-8)
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
 
 static int get_func2(int argc, VALUE *argv, VALUE obj, VALUE *ff, VALUE *xx, VALUE *hh)
 {

--- a/ext/gsl/deriv.c
+++ b/ext/gsl/deriv.c
@@ -74,11 +74,6 @@ static VALUE rb_gsl_deriv_eval(VALUE obj, VALUE xx, VALUE hh,
   gsl_matrix *m = NULL, *mnew = NULL, *merr = NULL;
   size_t n, i, j;
   int status;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2, *ptr3;
-  VALUE ary2, ary3;
-#endif
   Need_Float(hh);
   Data_Get_Struct(obj, gsl_function, f);
   h = NUM2DBL(hh);
@@ -107,6 +102,9 @@ static VALUE rb_gsl_deriv_eval(VALUE obj, VALUE xx, VALUE hh,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2, *ptr3;
+      VALUE ary2, ary3;
       GetNArray(xx, na);
       n = na->total;
       ptr1 = (double*) na->ptr;

--- a/ext/gsl/dht.c
+++ b/ext/gsl/dht.c
@@ -13,9 +13,6 @@
 #include "include/rb_gsl_array.h"
 #include "include/rb_gsl_common.h"
 #include <gsl/gsl_dht.h>
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
 
 static VALUE rb_gsl_dht_alloc(int argc, VALUE *argv, VALUE klass)
 {

--- a/ext/gsl/dht.c
+++ b/ext/gsl/dht.c
@@ -52,9 +52,6 @@ static VALUE rb_gsl_dht_apply(int argc, VALUE *argv, VALUE obj)
   double *ptr1, *ptr2;
   gsl_vector *vin, *vout;
   size_t size, stride;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-#endif
   VALUE ary;
   switch (argc) {
   case 2:
@@ -73,6 +70,7 @@ static VALUE rb_gsl_dht_apply(int argc, VALUE *argv, VALUE obj)
       ary = Data_Wrap_Struct(VECTOR_ROW_COL(argv[0]), 0, gsl_vector_free, vout);
 #ifdef HAVE_NARRAY_H
     } else if (NA_IsNArray(argv[0])) {
+      struct NARRAY *na;
       GetNArray(argv[0], na);
       ptr1 = (double*)na->ptr;
       ary = na_make_object(NA_DFLOAT, na->rank, na->shape, CLASS_OF(argv[0]));
@@ -102,11 +100,6 @@ static VALUE rb_gsl_dht_xk_sample(VALUE obj, VALUE n,
   int nn;
   VALUE ary;
   double val;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  int *ptr;
-  double *ptr2;
-#endif
   Data_Get_Struct(obj, gsl_dht, t);
   if (CLASS_OF(n) == rb_cRange) n = rb_gsl_range2ary(n);
   switch (TYPE(n)) {
@@ -136,6 +129,9 @@ static VALUE rb_gsl_dht_xk_sample(VALUE obj, VALUE n,
       return Data_Wrap_Struct(cgsl_vector, 0, gsl_vector_free, v);
 #ifdef HAVE_NARRAY_H
     } else if (NA_IsNArray(n)) {
+      struct NARRAY *na;
+      int *ptr;
+      double *ptr2;
       GetNArray(n, na);
       ptr = (int*) na->ptr;
       size = na->total;

--- a/ext/gsl/diff.c
+++ b/ext/gsl/diff.c
@@ -48,11 +48,6 @@ static VALUE rb_gsl_diff_eval(VALUE obj, VALUE xx,
   gsl_matrix *m = NULL, *mnew = NULL, *merr = NULL;
   size_t n, i, j;
   int status;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2, *ptr3;
-  struct NARRAY *na;
-  VALUE ary2, ary3;
-#endif
   Data_Get_Struct(obj, gsl_function, f);
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch (TYPE(xx)) {
@@ -79,6 +74,9 @@ static VALUE rb_gsl_diff_eval(VALUE obj, VALUE xx,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      double *ptr1, *ptr2, *ptr3;
+      struct NARRAY *na;
+      VALUE ary2, ary3;
       GetNArray(xx, na);
       n = na->total;
       ptr1 = (double*) na->ptr;

--- a/ext/gsl/fft.c
+++ b/ext/gsl/fft.c
@@ -588,9 +588,6 @@ static VALUE rb_fft_radix2(VALUE obj,
   gsl_vector_view vv;
   double *ptr1, *ptr2;
   int flag;
-#ifdef HAVE_NARRAY_H
-  int shape[1];
-#endif
   VALUE ary;
   get_ptr_stride_n(obj, &ptr1, &stride, &n, &flag);
   if (flag == 0) {
@@ -610,6 +607,7 @@ static VALUE rb_fft_radix2(VALUE obj,
 #ifdef HAVE_NARRAY_H
   } else if (flag == 1) {
     if (sss == RB_GSL_FFT_COPY) {
+      int shape[1];
       shape[0] = n;
       ary = na_make_object(NA_DFLOAT, 1, shape, cNArray);
       ptr2 = NA_PTR_TYPE(ary, double*);
@@ -678,9 +676,6 @@ static VALUE rb_fft_real_trans(int argc, VALUE *argv, VALUE obj,
   gsl_vector *vnew;
   gsl_vector_view vv;
   double *ptr1, *ptr2;
-#ifdef HAVE_NARRAY_H
-  int shape[1];
-#endif
   gsl_fft_real_wavetable *table = NULL;
   gsl_fft_real_workspace *space = NULL;
   VALUE ary;
@@ -702,6 +697,7 @@ static VALUE rb_fft_real_trans(int argc, VALUE *argv, VALUE obj,
 #ifdef HAVE_NARRAY_H
   } else if (naflag == 1) {
     if (sss == RB_GSL_FFT_COPY) {
+      int shape[1];
       shape[0] = n;
       ary = na_make_object(NA_DFLOAT, 1, shape, cNArray);
       ptr2 = NA_PTR_TYPE(ary, double*);
@@ -744,9 +740,6 @@ static VALUE rb_fft_halfcomplex_trans(int argc, VALUE *argv, VALUE obj,
   gsl_vector *vnew;
   gsl_vector_view vv;
   double *ptr1, *ptr2;
-#ifdef HAVE_NARRAY_H
-  int shape[1];
-#endif
   gsl_fft_halfcomplex_wavetable *table = NULL;
   gsl_fft_real_workspace *space = NULL;
   VALUE ary;
@@ -769,6 +762,7 @@ static VALUE rb_fft_halfcomplex_trans(int argc, VALUE *argv, VALUE obj,
 #ifdef HAVE_NARRAY_H
   } else if (naflag == 1) {
     if (sss == RB_GSL_FFT_COPY) {
+      int shape[1];
       shape[0] = n;
       ary = na_make_object(NA_DFLOAT, 1, shape, cNArray);
       ptr2 = NA_PTR_TYPE(ary, double*);

--- a/ext/gsl/function.c
+++ b/ext/gsl/function.c
@@ -10,9 +10,6 @@
 */
 
 #include "include/rb_gsl_function.h"
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
 
 VALUE cgsl_function;
 VALUE cgsl_function_fdf;

--- a/ext/gsl/function.c
+++ b/ext/gsl/function.c
@@ -108,10 +108,6 @@ static VALUE rb_gsl_function_eval(VALUE obj, VALUE x)
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *mnew = NULL;
   size_t i, j, n;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   Data_Get_Struct(obj, gsl_function, F);
   ary = (VALUE) F->params;
   proc = rb_ary_entry(ary, 0);
@@ -141,6 +137,8 @@ static VALUE rb_gsl_function_eval(VALUE obj, VALUE x)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(x)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       GetNArray(x, na);
       ptr1 = (double *) na->ptr;
       n = na->total;

--- a/ext/gsl/gsl_narray.c
+++ b/ext/gsl/gsl_narray.c
@@ -7,7 +7,6 @@
 
 #ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_array.h"
-#include "narray.h"
 #include "include/rb_gsl_with_narray.h"
 
 static VALUE rb_gsl_na_to_gsl_matrix_method(VALUE nna);
@@ -575,7 +574,6 @@ gsl_matrix_int_view* na_to_gm_int_view(VALUE nna)
   return m;
 }
 
-#include "narray.h"
 #include <gsl/gsl_histogram.h>
 EXTERN VALUE cgsl_histogram;
 static VALUE rb_gsl_narray_histogram(int argc, VALUE *argv, VALUE obj)

--- a/ext/gsl/gsl_narray.c
+++ b/ext/gsl/gsl_narray.c
@@ -575,7 +575,6 @@ gsl_matrix_int_view* na_to_gm_int_view(VALUE nna)
   return m;
 }
 
-#ifdef HAVE_NARRAY_H
 #include "narray.h"
 #include <gsl/gsl_histogram.h>
 EXTERN VALUE cgsl_histogram;
@@ -652,7 +651,6 @@ static VALUE rb_gsl_narray_histogram(int argc, VALUE *argv, VALUE obj)
     gsl_histogram_increment(h, ptr[i*stride]);
   return Data_Wrap_Struct(cgsl_histogram, 0, gsl_histogram_free, h);
 }
-#endif
 
 /*void rb_gsl_with_narray_define_methods()*/
 void Init_gsl_narray(VALUE module)

--- a/ext/gsl/histogram.c
+++ b/ext/gsl/histogram.c
@@ -336,10 +336,6 @@ static VALUE rb_gsl_histogram_accumulate(int argc, VALUE *argv, VALUE obj)
   gsl_vector_int *vi;
   size_t i;
   double weight = 1;
-#ifdef HAVE_NARRAY_H
-  double *ptr;
-  size_t size, stride;
-#endif
   switch (argc) {
   case 2:
     Need_Float(argv[1]);
@@ -367,6 +363,8 @@ static VALUE rb_gsl_histogram_accumulate(int argc, VALUE *argv, VALUE obj)
       gsl_histogram_accumulate(h, (double)gsl_vector_int_get(vi, i), weight);
 #ifdef HAVE_NARRAY_H
   } else if (NA_IsNArray(argv[0])) {
+    double *ptr;
+    size_t size, stride;
     ptr = get_vector_ptr(argv[0], &stride, &size);
     for (i = 0; i < size; i++)
       gsl_histogram_accumulate(h, ptr[i], weight);

--- a/ext/gsl/include/rb_gsl_fft.h
+++ b/ext/gsl/include/rb_gsl_fft.h
@@ -18,9 +18,6 @@
 #include <gsl/gsl_fft_real.h>
 #include <gsl/gsl_fft_halfcomplex.h>
 #include "rb_gsl.h"
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
 
 typedef struct
 {

--- a/ext/gsl/include/rb_gsl_linalg.h
+++ b/ext/gsl/include/rb_gsl_linalg.h
@@ -14,7 +14,6 @@
 
 #include <gsl/gsl_linalg.h>
 #include <gsl/gsl_math.h>
-#include "rb_gsl_with_narray.h"
 
 VALUE rb_gsl_linalg_complex_LU_decomp(int argc, VALUE *argv, VALUE obj);
 VALUE rb_gsl_linalg_complex_LU_decomp2(int argc, VALUE *argv, VALUE obj);

--- a/ext/gsl/interp.c
+++ b/ext/gsl/interp.c
@@ -181,10 +181,6 @@ static VALUE rb_gsl_interp_evaluate(VALUE obj, VALUE xxa, VALUE yya, VALUE xx,
   VALUE ary, x;
   double val;
   size_t n, i, j, size, stridex, stridey;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na = NULL;
-  double *ptrz = NULL, *ptr = NULL;
-#endif
   Data_Get_Struct(obj, rb_gsl_interp, rgi);
   ptrx = get_vector_ptr(xxa, &stridex, &size);
   if (size != rgi->p->size ){
@@ -215,6 +211,8 @@ static VALUE rb_gsl_interp_evaluate(VALUE obj, VALUE xxa, VALUE yya, VALUE xx,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na = NULL;
+      double *ptrz = NULL, *ptr = NULL;
       GetNArray(xx, na);
       ptrz = (double*) na->ptr;
       ary = na_make_object(NA_DFLOAT, na->rank, na->shape, CLASS_OF(xx));

--- a/ext/gsl/jacobi.c
+++ b/ext/gsl/jacobi.c
@@ -18,10 +18,6 @@ static VALUE jac_eval3(VALUE xx, VALUE aa, VALUE bb, double (*f)(double, double,
   double a, b;
   size_t i, len;
   VALUE ary;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   a = NUM2DBL(aa);
   b = NUM2DBL(bb);
   if (VECTOR_P(xx)) {
@@ -41,6 +37,8 @@ static VALUE jac_eval3(VALUE xx, VALUE aa, VALUE bb, double (*f)(double, double,
     return ary;
 #ifdef HAVE_NARRAY_H
   } else if (NA_IsNArray(xx)) {
+    double *ptr1, *ptr2;
+    struct NARRAY *na;
     GetNArray(xx, na);
     len = na->total;
     ptr1 = (double*) na->ptr;
@@ -65,10 +63,6 @@ static VALUE rb_jac_jacobi_eval(int argc, VALUE *argv,
   VALUE ary;
   size_t len, i;
   int n, flag = 0;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   if (argc < 4) rb_raise(rb_eArgError, "Too few arguments (%d for >= 4)", argc);
   if (VECTOR_P(argv[0])) {
     Data_Get_Struct(argv[0], gsl_vector, x);
@@ -103,6 +97,8 @@ static VALUE rb_jac_jacobi_eval(int argc, VALUE *argv,
     return ary;
 #ifdef HAVE_NARRAY_H
   } else if (NA_IsNArray(argv[0])) {
+    double *ptr1, *ptr2;
+    struct NARRAY *na;
     GetNArray(argv[0], na);
     len = na->total;
     ptr1 = (double*) na->ptr;

--- a/ext/gsl/math.c
+++ b/ext/gsl/math.c
@@ -12,9 +12,6 @@
 
 #include "include/rb_gsl_math.h"
 #include "include/rb_gsl_complex.h"
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
 
 static void rb_gsl_define_const(VALUE module);
 

--- a/ext/gsl/math.c
+++ b/ext/gsl/math.c
@@ -140,10 +140,6 @@ static VALUE rb_gsl_math_eval(double (*func)(const double), VALUE xx)
 {
   VALUE x, ary;
   size_t i, size;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch (TYPE(xx)) {
   case T_FIXNUM:
@@ -165,6 +161,8 @@ static VALUE rb_gsl_math_eval(double (*func)(const double), VALUE xx)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       GetNArray(xx, na);
       ptr1 = (double*) na->ptr;
       size = na->total;
@@ -196,10 +194,6 @@ static VALUE rb_gsl_math_eval2(double (*func)(const double, const double), VALUE
   size_t i, j, size;
   gsl_vector *v = NULL, *v2 = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *m2 = NULL, *mnew = NULL;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *nax, *nay;
-  double *ptr1, *ptr2, *ptr3;
-#endif
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch (TYPE(xx)) {
   case T_FIXNUM:
@@ -226,6 +220,8 @@ static VALUE rb_gsl_math_eval2(double (*func)(const double, const double), VALUE
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *nax, *nay;
+      double *ptr1, *ptr2, *ptr3;
       GetNArray(xx, nax);
       GetNArray(yy, nay);
       ptr1 = (double*) nax->ptr;
@@ -328,10 +324,6 @@ VALUE rb_gsl_pow(VALUE obj, VALUE xx, VALUE nn)
   double n;
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *mnew = NULL;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch (TYPE(xx)) {
   case T_FIXNUM:
@@ -353,6 +345,8 @@ VALUE rb_gsl_pow(VALUE obj, VALUE xx, VALUE nn)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       n = NUM2DBL(nn);
       GetNArray(xx, na);
       ptr1 = (double*) na->ptr;
@@ -402,10 +396,6 @@ static VALUE rb_gsl_pow_int(VALUE obj, VALUE xx, VALUE nn)
   int n;
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *mnew = NULL;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
 
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch (TYPE(xx)) {
@@ -430,6 +420,8 @@ static VALUE rb_gsl_pow_int(VALUE obj, VALUE xx, VALUE nn)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       CHECK_FIXNUM(nn);
       n = FIX2INT(nn);
       GetNArray(xx, na);

--- a/ext/gsl/matrix.c
+++ b/ext/gsl/matrix.c
@@ -18,9 +18,7 @@
 #include "include/rb_gsl_histogram.h"
 #include "include/rb_gsl_complex.h"
 #include "include/rb_gsl_poly.h"
-#ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_with_narray.h"
-#endif
 
 int gsl_linalg_matmult_int(const gsl_matrix_int *A,
          const gsl_matrix_int *B, gsl_matrix_int *C);

--- a/ext/gsl/matrix_double.c
+++ b/ext/gsl/matrix_double.c
@@ -11,9 +11,7 @@
 
 #include "include/rb_gsl_array.h"
 #include "include/rb_gsl_complex.h"
-#ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_with_narray.h"
-#endif
 
 enum {
   GSL_MATRIX_ADD,

--- a/ext/gsl/matrix_source.c
+++ b/ext/gsl/matrix_source.c
@@ -257,16 +257,14 @@ static VALUE FUNCTION(rb_gsl_matrix,alloc)(int argc, VALUE *argv, VALUE klass)
 {
   GSL_TYPE(gsl_matrix) *m = NULL;
   size_t n1, n2;
-#ifdef HAVE_NARRAY_H
-  size_t n;
-  VALUE ary;
-  struct NARRAY *na;
-#endif
   if (argc < 1) rb_raise(rb_eArgError,
        "wrong number of arguments (%d for >= 1)", argc);
 
 #ifdef HAVE_NARRAY_H
   if (NA_IsNArray(argv[0])) {
+    size_t n;
+    VALUE ary;
+    struct NARRAY *na;
     GetNArray(argv[0], na);
     n = na->shape[0]*na->shape[1];
     m = FUNCTION(gsl_matrix,alloc)(na->shape[1], na->shape[0]);

--- a/ext/gsl/poly.c
+++ b/ext/gsl/poly.c
@@ -12,9 +12,6 @@
 #include "include/rb_gsl_poly.h"
 #include "include/rb_gsl_array.h"
 #include "include/rb_gsl_common.h"
-#ifdef HAVE_NARARY_H
-#include "narray.h"
-#endif
 
 void Init_gsl_poly_init(VALUE module);
 void Init_gsl_poly_int_init(VALUE module);

--- a/ext/gsl/poly_source.c
+++ b/ext/gsl/poly_source.c
@@ -67,7 +67,6 @@ double gsl_poly_int_eval(const BASE c[], const int len, const double x)
 }
 #endif
 #ifdef BASE_DOUBLE
-#include "include/rb_gsl_with_narray.h"
 #ifdef GSL_1_11_LATER
 static VALUE rb_gsl_complex_poly_complex_eval(VALUE a, VALUE b);
 #endif

--- a/ext/gsl/poly_source.c
+++ b/ext/gsl/poly_source.c
@@ -67,9 +67,7 @@ double gsl_poly_int_eval(const BASE c[], const int len, const double x)
 }
 #endif
 #ifdef BASE_DOUBLE
-#ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_with_narray.h"
-#endif
 #ifdef GSL_1_11_LATER
 static VALUE rb_gsl_complex_poly_complex_eval(VALUE a, VALUE b);
 #endif
@@ -83,9 +81,6 @@ static VALUE rb_gsl_poly_eval_singleton(VALUE klass, VALUE a, VALUE x)
   VALUE val;
   double *ptr0;
   double *ptr1, *ptr2;
-#ifdef HAVE_NARRAY_H
-  int shape[1];
-#endif
 #ifdef GSL_1_11_LATER
   gsl_complex *z, zz;
   gsl_vector_complex *vz, *vznew;
@@ -149,6 +144,7 @@ static VALUE rb_gsl_poly_eval_singleton(VALUE klass, VALUE a, VALUE x)
       ptr2 = mnew->data;
 #ifdef HAVE_NARRAY_H
     } else if (NA_IsNArray(x)) {
+      int shape[1];
       shape[0] = NA_TOTAL(x);
       n = shape[0];
       val = na_make_object(NA_DFLOAT, 1, shape, CLASS_OF(x));
@@ -261,11 +257,6 @@ static VALUE FUNCTION(rb_gsl_poly,eval)(VALUE obj, VALUE xx)
   VALUE x, ary;
   size_t i, j;
 #ifdef BASE_DOUBLE
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-  size_t n;
-#endif
 #ifdef GSL_1_11_LATER
   gsl_complex *z, zz;
   gsl_vector_complex *vz, *vznew;
@@ -293,6 +284,9 @@ static VALUE FUNCTION(rb_gsl_poly,eval)(VALUE obj, VALUE xx)
 #ifdef BASE_DOUBLE
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
+      size_t n;
       GetNArray(xx, na);
       ptr1 = (double*) na->ptr;
       n = na->total;
@@ -355,12 +349,6 @@ static VALUE FUNCTION(rb_gsl_poly,eval2)(int argc, VALUE *argv, VALUE obj)
   gsl_matrix  *mnew = NULL;
   VALUE xx, x, ary;
   size_t i, j, size;
-#ifdef BASE_DOUBLE
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
-#endif
   switch (argc) {
   case 2:
     Data_Get_Struct(argv[0], GSL_TYPE(gsl_poly), p);
@@ -396,6 +384,8 @@ static VALUE FUNCTION(rb_gsl_poly,eval2)(int argc, VALUE *argv, VALUE obj)
 #ifdef BASE_DOUBLE
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       GetNArray(xx, na);
       ptr1 = (double*) na->ptr;
       size = na->total;
@@ -1660,11 +1650,6 @@ static VALUE rb_gsl_poly_eval_derivs_singleton(int argc, VALUE *argv, VALUE klas
   VALUE ary;
   gsl_vector *v = NULL, *v2 = NULL;
   size_t i, lenc, lenres;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-  int shape[1];
-#endif
 
   if (argc < 2) rb_raise(rb_eArgError, "Wrong number of arguments (%d for >= 2)", argc);
   if (rb_obj_is_kind_of(argv[0], rb_cArray)) {
@@ -1696,6 +1681,9 @@ static VALUE rb_gsl_poly_eval_derivs_singleton(int argc, VALUE *argv, VALUE klas
   }
 #ifdef HAVE_NARRAY_H
   if (NA_IsNArray(argv[0])) {
+    struct NARRAY *na;
+    double *ptr1, *ptr2;
+    int shape[1];
     GetNArray(argv[0], na);
     ptr1 = (double*) na->ptr;
     lenc = na->total;

--- a/ext/gsl/randist.c
+++ b/ext/gsl/randist.c
@@ -1291,10 +1291,6 @@ VALUE rb_gsl_eval_pdf_cdf(VALUE xx, double (*f)(double))
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *mnew = NULL;
   size_t i, j, n;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch(TYPE(xx)) {
   case T_FIXNUM:
@@ -1316,6 +1312,8 @@ VALUE rb_gsl_eval_pdf_cdf(VALUE xx, double (*f)(double))
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       xx = na_change_type(xx, NA_DFLOAT);
       GetNArray(xx, na);
       ptr1 = (double *) na->ptr;
@@ -1359,10 +1357,6 @@ VALUE rb_gsl_eval_pdf_cdf2(VALUE xx, VALUE aa,
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *mnew = NULL;
   size_t i, j, n;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
   Need_Float(aa);
   a = NUM2DBL(aa);
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
@@ -1386,6 +1380,8 @@ VALUE rb_gsl_eval_pdf_cdf2(VALUE xx, VALUE aa,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       xx = na_change_type(xx, NA_DFLOAT);
       GetNArray(xx, na);
       ptr1 = (double *) na->ptr;
@@ -1429,10 +1425,6 @@ VALUE rb_gsl_eval_pdf_cdf3(VALUE xx, VALUE aa, VALUE bb,
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *m = NULL, *mnew = NULL;
   size_t i, j, n;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  double *ptr1, *ptr2;
-#endif
   Need_Float(aa);  Need_Float(bb);
   a = NUM2DBL(aa); b = NUM2DBL(bb);
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
@@ -1456,6 +1448,8 @@ VALUE rb_gsl_eval_pdf_cdf3(VALUE xx, VALUE aa, VALUE bb,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      double *ptr1, *ptr2;
       xx = na_change_type(xx, NA_DFLOAT);
       GetNArray(xx, na);
       ptr1 = (double *) na->ptr;
@@ -1501,10 +1495,6 @@ VALUE rb_gsl_eval_pdf_cdf2_uint(VALUE xx, VALUE aa,
   gsl_matrix *m = NULL, *mnew = NULL;
   gsl_matrix_int *mi = NULL;
   size_t i, j, n;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *na;
-  char *ptr1, *ptr2;
-#endif
   Need_Float(aa);
   a = NUM2DBL(aa);
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
@@ -1527,6 +1517,8 @@ VALUE rb_gsl_eval_pdf_cdf2_uint(VALUE xx, VALUE aa,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      struct NARRAY *na;
+      char *ptr1, *ptr2;
       GetNArray(xx, na);
       n = na->total;
       ary = na_make_object(na->type, na->rank, na->shape, CLASS_OF(xx));

--- a/ext/gsl/randist.c
+++ b/ext/gsl/randist.c
@@ -1280,10 +1280,6 @@ static VALUE rb_gsl_ran_discrete_pdf(VALUE obj, VALUE k, VALUE gg)
   return rb_float_new(gsl_ran_discrete_pdf(FIX2INT(k), g));
 }
 
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
-
 /*****/
 VALUE rb_gsl_eval_pdf_cdf(VALUE xx, double (*f)(double))
 {

--- a/ext/gsl/sf.c
+++ b/ext/gsl/sf.c
@@ -154,10 +154,6 @@ VALUE rb_gsl_sf_eval_int_double(double (*func)(int, double), VALUE jj, VALUE arg
   VALUE ary, xx;
   size_t i, j, k, n;
   double val;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   CHECK_FIXNUM(jj);
   j = FIX2INT(jj);
   if (CLASS_OF(argv) == rb_cRange) argv = rb_gsl_range2ary(argv);
@@ -181,6 +177,8 @@ VALUE rb_gsl_sf_eval_int_double(double (*func)(int, double), VALUE jj, VALUE arg
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -223,10 +221,6 @@ VALUE rb_gsl_sf_eval_double_int(double (*func)(double, int), VALUE argv, VALUE j
   VALUE ary, xx;
   size_t i, j, k, n;
   double val;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   CHECK_FIXNUM(jj);
   j = FIX2INT(jj);
   if (CLASS_OF(argv) == rb_cRange) argv = rb_gsl_range2ary(argv);
@@ -250,6 +244,8 @@ VALUE rb_gsl_sf_eval_double_int(double (*func)(double, int), VALUE argv, VALUE j
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -294,10 +290,6 @@ VALUE rb_gsl_sf_eval_int_int_double(double (*func)(int, int, double), VALUE jj,
   VALUE ary, xx;
   size_t i, j, k, j2, n;
   double val;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   CHECK_FIXNUM(jj); CHECK_FIXNUM(jj2);
   j = FIX2INT(jj);
   j2 = FIX2INT(jj2);
@@ -322,6 +314,8 @@ VALUE rb_gsl_sf_eval_int_int_double(double (*func)(int, int, double), VALUE jj,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -365,10 +359,6 @@ VALUE rb_gsl_sf_eval_int_double_double(double (*func)(int, double, double), VALU
   VALUE ary, xx;
   size_t i, j, k, n;
   double f, val;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   CHECK_FIXNUM(jj);
   Need_Float(ff);
   j = FIX2INT(jj);
@@ -394,6 +384,8 @@ VALUE rb_gsl_sf_eval_int_double_double(double (*func)(int, double, double), VALU
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -436,10 +428,6 @@ VALUE rb_gsl_sf_eval_double_double(double (*func)(double, double), VALUE ff, VAL
   VALUE ary, xx;
   size_t i, k, n;
   double val, f;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   Need_Float(ff);
   f = NUM2DBL(ff);
   if (CLASS_OF(argv) == rb_cRange) argv = rb_gsl_range2ary(argv);
@@ -463,6 +451,8 @@ VALUE rb_gsl_sf_eval_double_double(double (*func)(double, double), VALUE ff, VAL
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -503,10 +493,6 @@ VALUE rb_gsl_sf_eval_double3(double (*func)(double, double, double),
   VALUE ary, xx;
   size_t i, k, n;
   double val, f, f2;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   Need_Float(ff); Need_Float(ff2);
   f = NUM2DBL(ff);
   f2 = NUM2DBL(ff2);
@@ -531,6 +517,8 @@ VALUE rb_gsl_sf_eval_double3(double (*func)(double, double, double),
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -574,10 +562,6 @@ VALUE rb_gsl_sf_eval_double4(double (*func)(double, double, double, double),
   VALUE ary, xx;
   size_t i, k, n;
   double val, f, f2, f3;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   Need_Float(ff); Need_Float(ff2); Need_Float(ff3);
   f = NUM2DBL(ff);
   f2 = NUM2DBL(ff2);
@@ -603,6 +587,8 @@ VALUE rb_gsl_sf_eval_double4(double (*func)(double, double, double, double),
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -645,10 +631,6 @@ VALUE rb_gsl_sf_eval1_int(double (*func)(int), VALUE argv)
   VALUE ary;
   size_t i, k, n;
   double val;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   if (CLASS_OF(argv) == rb_cRange) argv = rb_gsl_range2ary(argv);
   switch (TYPE(argv)) {
   case T_FIXNUM:
@@ -668,6 +650,8 @@ VALUE rb_gsl_sf_eval1_int(double (*func)(int), VALUE argv)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -710,10 +694,6 @@ VALUE rb_gsl_sf_eval1_uint(double (*func)(unsigned int), VALUE argv)
   VALUE ary;
   size_t i, k, n;
   double val;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   if (CLASS_OF(argv) == rb_cRange) argv = rb_gsl_range2ary(argv);
   switch (TYPE(argv)) {
   case T_FIXNUM:
@@ -733,6 +713,8 @@ VALUE rb_gsl_sf_eval1_uint(double (*func)(unsigned int), VALUE argv)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       argv = na_change_type(argv, NA_DFLOAT);
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
@@ -777,10 +759,6 @@ VALUE rb_gsl_sf_eval_double_m(double (*func)(double, gsl_mode_t), VALUE argv, VA
   double val;
   /*gsl_mode_t mode;
   char c;*/
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   switch (TYPE(m)) {
   case T_STRING:
     /*c = tolower(NUM2CHR(m));
@@ -817,6 +795,8 @@ VALUE rb_gsl_sf_eval_double_m(double (*func)(double, gsl_mode_t), VALUE argv, VA
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
       n = na->total;
@@ -861,10 +841,6 @@ VALUE rb_gsl_sf_eval_double2_m(double (*func)(double, double, gsl_mode_t),
   double val, xx2;
   /*gsl_mode_t mode;
   char c;*/
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   Need_Float(x2);
   xx2 = NUM2DBL(x2);
   /*c = tolower(NUM2CHR(m));
@@ -893,6 +869,8 @@ VALUE rb_gsl_sf_eval_double2_m(double (*func)(double, double, gsl_mode_t),
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
       n = na->total;
@@ -937,10 +915,6 @@ VALUE rb_gsl_sf_eval_double3_m(double (*func)(double, double, double, gsl_mode_t
   double val, xx2, xx3;
   /*gsl_mode_t mode;
   char c;*/
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   Need_Float(x2); Need_Float(x3);
   xx2 = NUM2DBL(x2);
   xx3 = NUM2DBL(x3);
@@ -970,6 +944,8 @@ VALUE rb_gsl_sf_eval_double3_m(double (*func)(double, double, double, gsl_mode_t
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
       n = na->total;
@@ -1015,10 +991,6 @@ VALUE rb_gsl_sf_eval_double4_m(double (*func)(double, double, double, double,
   double val, xx2, xx3, xx4;
   /*gsl_mode_t mode;
   char c;*/
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   Need_Float(x2); Need_Float(x3); Need_Float(x4);
   xx2 = NUM2DBL(x2);  xx3 = NUM2DBL(x3); xx4 = NUM2DBL(x4);
   /*c = tolower(NUM2CHR(m));
@@ -1048,6 +1020,8 @@ VALUE rb_gsl_sf_eval_double4_m(double (*func)(double, double, double, double,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
       n = na->total;
@@ -1319,10 +1293,6 @@ VALUE eval_sf(double (*func)(double, gsl_mode_t), VALUE argv)
   double val;
   gsl_vector *v = NULL, *vnew = NULL;
   gsl_matrix *mm = NULL, *mnew = NULL;
-#ifdef HAVE_NARRAY_H
-  double *ptr1, *ptr2;
-  struct NARRAY *na;
-#endif
   switch (TYPE(argv)) {
   case T_FLOAT:
   case T_FIXNUM:
@@ -1343,6 +1313,8 @@ VALUE eval_sf(double (*func)(double, gsl_mode_t), VALUE argv)
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv)) {
+      double *ptr1, *ptr2;
+      struct NARRAY *na;
       ptr1 = NA_PTR_TYPE(argv, double*);
       GetNArray(argv, na);
       n = na->total;

--- a/ext/gsl/sf.c
+++ b/ext/gsl/sf.c
@@ -12,9 +12,6 @@
 
 #include "include/rb_gsl_array.h"
 #include "include/rb_gsl_sf.h"
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
 
 VALUE cgsl_sf_result, cgsl_sf_result_e10;
 

--- a/ext/gsl/signal.c
+++ b/ext/gsl/signal.c
@@ -105,11 +105,7 @@ static VALUE rb_gsl_fft_conv_corr(int argc, VALUE *argv, VALUE obj,
 {
   double *data1, *data2, *data3 = NULL;
   size_t stride1, stride2, size1, size2;
-#ifdef HAVE_NARRAY_H
-  int naflag1, naflag2, shape;
-#else
   int naflag1, naflag2;
-#endif
   gsl_vector *v = NULL;
   gsl_fft_halfcomplex_wavetable *table = NULL;
   gsl_fft_real_wavetable *rtable = NULL;
@@ -172,9 +168,11 @@ static VALUE rb_gsl_fft_conv_corr(int argc, VALUE *argv, VALUE obj,
     break;
   case 1:
 #ifdef HAVE_NARRAY_H
-    shape = (int) size1;
-    ary = na_make_object(NA_DFLOAT, 1, &shape, cNArray);
-    data3 = NA_PTR_TYPE(ary, double*);
+    {
+      int shape = (int) size1;
+      ary = na_make_object(NA_DFLOAT, 1, &shape, cNArray);
+      data3 = NA_PTR_TYPE(ary, double*);
+    }
 #endif
     break;
   default:

--- a/ext/gsl/sort.c
+++ b/ext/gsl/sort.c
@@ -141,7 +141,6 @@ static VALUE rb_gsl_heapsort_index(VALUE obj, VALUE vv)
 /*****/
 
 #ifdef HAVE_NARRAY_H
-#include "narray.h"
 static VALUE rb_gsl_sort_narray(VALUE obj)
 {
   struct NARRAY *na;

--- a/ext/gsl/spline.c
+++ b/ext/gsl/spline.c
@@ -65,9 +65,6 @@ static VALUE rb_gsl_spline_init(VALUE obj, VALUE xxa, VALUE yya)
   size_t i, size;
   int flagx = 0, flagy = 0;
   double *ptr1 = NULL, *ptr2 = NULL;
-#ifdef HAVE_NARRAY_H
-  struct NARRAY *nax = NULL, *nay = NULL;
-#endif
   Data_Get_Struct(obj, rb_gsl_spline, sp);
   p = sp->s;
   if (TYPE(xxa) == T_ARRAY) {
@@ -83,9 +80,10 @@ static VALUE rb_gsl_spline_init(VALUE obj, VALUE xxa, VALUE yya)
     ptr1 = xa->data;
 #ifdef HAVE_NARRAY_H
   } else if (NA_IsNArray(xxa)) {
-      GetNArray(xxa, nax);
-      size = nax->total;
-      ptr1 = (double *) nax->ptr;
+    struct NARRAY *nax = NULL;
+    GetNArray(xxa, nax);
+    size = nax->total;
+    ptr1 = (double *) nax->ptr;
 #endif
   } else {
     rb_raise(rb_eTypeError, "not a vector");
@@ -97,6 +95,7 @@ static VALUE rb_gsl_spline_init(VALUE obj, VALUE xxa, VALUE yya)
     flagy = 1;
 #ifdef HAVE_NARRAY_H
   } else if (NA_IsNArray(yya)) {
+    struct NARRAY *nay = NULL;
       GetNArray(yya, nay);
       ptr2 = (double *) nay->ptr;
 #endif
@@ -129,10 +128,6 @@ static VALUE rb_gsl_spline_evaluate(VALUE obj, VALUE xx,
   VALUE ary, x;
   double val;
   size_t n, i, j;
-#ifdef HAVE_NARRAY_H
-  double *ptr1 = NULL, *ptr2 = NULL;
-  struct NARRAY *na = NULL;
-#endif
   Data_Get_Struct(obj, rb_gsl_spline, rgs);
   if (CLASS_OF(xx) == rb_cRange) xx = rb_gsl_range2ary(xx);
   switch (TYPE(xx)) {
@@ -155,6 +150,8 @@ static VALUE rb_gsl_spline_evaluate(VALUE obj, VALUE xx,
   default:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(xx)) {
+      double *ptr1 = NULL, *ptr2 = NULL;
+      struct NARRAY *na = NULL;
       GetNArray(xx, na);
       ptr1 = (double *) na->ptr;
       n = na->total;

--- a/ext/gsl/stats.c
+++ b/ext/gsl/stats.c
@@ -11,9 +11,6 @@
 
 #include "include/rb_gsl_array.h"
 #include "include/rb_gsl_statistics.h"
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
 
 static double* get_vector_stats2(int argc, VALUE *argv, VALUE obj,
          size_t *stride, size_t *size)

--- a/ext/gsl/tensor.c
+++ b/ext/gsl/tensor.c
@@ -18,9 +18,7 @@
 
 #include "include/rb_gsl_tensor.h"
 
-#ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_with_narray.h"
-#endif
 
 #define BASE_DOUBLE
 #include "include/templates_on.h"

--- a/ext/gsl/vector.c
+++ b/ext/gsl/vector.c
@@ -18,9 +18,7 @@
 #include "include/rb_gsl_histogram.h"
 #include "include/rb_gsl_complex.h"
 #include "include/rb_gsl_poly.h"
-#ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_with_narray.h"
-#endif
 
 #define BASE_DOUBLE
 #include "include/templates_on.h"

--- a/ext/gsl/vector_int.c
+++ b/ext/gsl/vector_int.c
@@ -12,9 +12,7 @@
 
 #include "include/rb_gsl_array.h"
 #include "include/rb_gsl_complex.h"
-#ifdef HAVE_NARRAY_H
 #include "include/rb_gsl_with_narray.h"
-#endif
 
 VALUE rb_gsl_vector_int_inner_product(int argc, VALUE *argv, VALUE obj);
 VALUE rb_gsl_vector_int_do_something(VALUE obj, void (*func)(gsl_vector_int*));

--- a/ext/gsl/vector_source.c
+++ b/ext/gsl/vector_source.c
@@ -210,13 +210,11 @@ VALUE FUNCTION(rb_gsl_vector,new)(int argc, VALUE *argv, VALUE klass)
   size_t n, i;
   BASE beg, en;
   int step;
-#ifdef HAVE_NARRAY_H
-  VALUE ary2;
-#endif
   switch (argc) {
   case 1:
 #ifdef HAVE_NARRAY_H
     if (NA_IsNArray(argv[0])) {
+      VALUE ary2;
       n = NA_TOTAL(argv[0]);
       v = FUNCTION(gsl_vector,alloc)(n);
       if (v == NULL) rb_raise(rb_eNoMemError, "gsl_vector_alloc failed");

--- a/ext/gsl/wavelet.c
+++ b/ext/gsl/wavelet.c
@@ -17,10 +17,6 @@
 #include <gsl/gsl_wavelet2d.h>
 #endif
 
-#ifdef HAVE_NARRAY_H
-#include "narray.h"
-#endif
-
 #ifndef CHECK_WAVELET
 #define CHECK_WAVELET(x) if(!rb_obj_is_kind_of(x,cgsl_wavelet))\
     rb_raise(rb_eTypeError, "wrong argument type (Wavelet expected)");


### PR DESCRIPTION
Following https://github.com/SciRuby/rb-gsl/issues/14 I tried to cut down the number of narray occurences to see how many there really are. `grep -r HAVE_NARRAY_H | wc` went down from 216 to 130. That's still a lot. But I think it would be better to try at first to carefully separate gsl and narray code to maybe achieve nmatrix/narray compatibility at some point, while still keeping it working in its current form.

I am not trying to create another fork here ;) These are trivial code changes, basically just removing some macros.

@v0dro @blackwinter what do you think?
